### PR TITLE
Implemented Create page for UCSBDiningCommonsMenuItem

### DIFF
--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.js
@@ -1,12 +1,49 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemCreatePage() {
+export default function UCSBDatesCreatePage({storybook=false}) {
 
-  // Stryker disable all : placeholder for future implementation
+  const objectToAxiosParams = (ucsbDiningCommonsMenuItem) => ({
+    url: "/api/UCSBDiningCommonsMenuItem/post",
+    method: "POST",
+    params: {
+      name: ucsbDiningCommonsMenuItem.name,
+      diningCommonsCode: ucsbDiningCommonsMenuItem.diningCommonsCode,
+      station: ucsbDiningCommonsMenuItem.station
+    }
+  });
+
+  const onSuccess = (ucsbDiningCommonsMenuItem) => {
+    toast(`New UCSBDiningCommonsMenuItem Created - id: ${ucsbDiningCommonsMenuItem.id} name: ${ucsbDiningCommonsMenuItem.name} diningCommonsCode: ${ucsbDiningCommonsMenuItem.diningCommonsCode} station: ${ucsbDiningCommonsMenuItem.station}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/UCSBDiningCommonsMenuItem/all"]
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/diningcommonsmenuitem" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New UCSBDiningCommonsMenuItem</h1>
+
+        <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} />
+
       </div>
     </BasicLayout>
   )

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage"
+
+export default {
+    title: 'pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage',
+    component: UCSBDiningCommonsMenuItemCreatePage
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/UCSBDiningCommonsMenuItem/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}
+
+
+

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -8,24 +8,60 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
 describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    const axiosMock =new AxiosMockAdapter(axios);
 
-    const setupUserOnly = () => {
+    beforeEach(() => {
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    test("renders without crashing", () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
 
-        setupUserOnly();
-       
-        // act
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const ucsbDiningCommonsMenuItem = {
+            id: 17,
+            name: "Cheese Pizza",
+            diningCommonsCode: "carillo",
+            station: "Pizza"
+        };
+
+        axiosMock.onPost("/api/UCSBDiningCommonsMenuItem/post").reply( 202, ucsbDiningCommonsMenuItem );
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -34,9 +70,36 @@ describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByTestId("UCSBDiningCommonsMenuItemForm-name")).toBeInTheDocument();
+        });
+
+        const nameField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-name");
+        const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+        const stationField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-station");
+        const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItemForm-submit");
+
+        fireEvent.change(nameField, { target: { value: 'Cheese Pizza' } });
+        fireEvent.change(diningCommonsCodeField, { target: { value: 'carillo' } });
+        fireEvent.change(stationField, { target: { value: 'Pizza' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+            "name": "Cheese Pizza",
+            "diningCommonsCode": "carillo",
+            "station": "Pizza"
+        });
+
+        expect(mockToast).toBeCalledWith("New UCSBDiningCommonsMenuItem Created - id: 17 name: Cheese Pizza diningCommonsCode: carillo station: Pizza");
+        expect(mockNavigate).toBeCalledWith({ "to": "/diningcommonsmenuitem" });
     });
+
 
 });
 


### PR DESCRIPTION
Closes #13 

Implemented the Create page, and its stories and tests, for UCSBDiningCommonsMenuItem. 

To use, go to https://team03-irreflexive-dev.dokku-09.cs.ucsb.edu/diningcommonsmenuitem/create and enter values in the fields. The page should look like this
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-1/assets/33270232/40cc993c-bb8d-49b2-a488-8dab4aa31f9e)

If all fields are properly filled out, you will be redirected back to the main page for UCSBDiningCommonsMenuItem and a toast will appear in the corner.
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-1/assets/33270232/11166cce-eab1-4ea0-aee4-042c84b11985)

The item should be visible when making a request to /api/UCSBDiningCommonsMenuItem/all using Swagger.

Storybook is available at https://ucsb-cs156-f23.github.io/team03-f23-7pm-1/prs/77/storybook
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-1/assets/33270232/549e5e12-d23c-42ef-9d98-68044fc7191b)
