### PR TITLE
Implemented Edit page for UCSBDiningCommonsMenuItem

### DIFF
--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.js
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.js
@@ -14,7 +14,7 @@ export default function UCSBDiningCommonsMenuItemTable({
     const navigate = useNavigate();
 
     const editCallback = (cell) => {
-        navigate(`/ucsbDiningCommonsMenuItems/edit/${cell.row.values.id}`)
+        navigate(`/diningcommonsmenuitem/edit/${cell.row.values.id}`)
     }
 
     // Stryker disable all : hard to test for query caching

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.js
@@ -1,13 +1,70 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemEditPage() {
+export default function UCSBDiningCommonsMenuItemEditPage({storybook=false}) {
+  let { id } = useParams();
 
-  // Stryker disable all : placeholder for future implementation
+  const { data: ucsbDiningCommonsMenuItem, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/UCSBDiningCommonsMenuItem?id=${id}`],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/UCSBDiningCommonsMenuItem`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (ucsbDiningCommonsMenuItem) => ({
+    url: "/api/UCSBDiningCommonsMenuItem",
+    method: "PUT",
+    params: {
+      id: ucsbDiningCommonsMenuItem.id,
+    },
+    data: {
+      name: ucsbDiningCommonsMenuItem.name,
+      diningCommonsCode: ucsbDiningCommonsMenuItem.diningCommonsCode,
+      station: ucsbDiningCommonsMenuItem.station
+    }
+  });
+
+  const onSuccess = (ucsbDiningCommonsMenuItem) => {
+    toast(`UCSBDiningCommonsMenuItem Updated - id: ${ucsbDiningCommonsMenuItem.id} name: ${ucsbDiningCommonsMenuItem.name} diningCommonsCode: ${ucsbDiningCommonsMenuItem.diningCommonsCode} station: ${ucsbDiningCommonsMenuItem.station}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/UCSBDiningCommonsMenuItem?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/diningcommonsmenuitem" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit UCSBDiningCommonsMenuItem</h1>
+        {
+          ucsbDiningCommonsMenuItem && <UCSBDiningCommonsMenuItemForm initialContents={ucsbDiningCommonsMenuItem} submitAction={onSubmit} buttonLabel="Update" />
+        }
       </div>
     </BasicLayout>
   )
 }
+

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDatesEditPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDatesEditPage.stories.js
@@ -1,0 +1,38 @@
+
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbDiningCommonsMenuItemFixtures } from 'fixtures/ucsbDiningCommonsMenuItemFixtures';
+import { rest } from "msw";
+
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+
+export default {
+    title: 'pages/UCSBDates/UCSBDatesEditPage',
+    component: UCSBDatesEditPage
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemEditPage storybook={true}/>;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/UCSBDiningCommonsMenuItem', (_req, res, ctx) => {
+            return res(ctx.json(ucsbDiningCommonsMenuItemFixtures.threeUcsbDiningCommonsMenuItems[0]));
+        }),
+        rest.put('/api/UCSBDiningCommonsMenuItem', async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}
+
+
+

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.stories.js
@@ -8,8 +8,8 @@ import { rest } from "msw";
 import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
 
 export default {
-    title: 'pages/UCSBDates/UCSBDatesEditPage',
-    component: UCSBDatesEditPage
+    title: 'pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage',
+    component: UCSBDiningCommonsMenuItemEditPage
 };
 
 const Template = () => <UCSBDiningCommonsMenuItemEditPage storybook={true}/>;

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.js
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.js
@@ -165,7 +165,7 @@ describe("UCSBDiningCommonsMenuItemTable tests", () => {
     fireEvent.click(editButton);
 
     // assert - check that the navigate function was called with the expected path
-    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsbDiningCommonsMenuItems/edit/2'));
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/diningcommonsmenuitem/edit/2'));
 
   });
 

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.js
@@ -1,44 +1,176 @@
-import { render, screen } from "@testing-library/react";
-import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 17
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    describe("when the backend doesn't return data", () => {
 
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+        const axiosMock = new AxiosMockAdapter(axios);
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/UCSBDiningCommonsMenuItem", { params: { id: 17 } }).timeout();
+        });
 
-        setupUserOnly();
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
 
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <UCSBDiningCommonsMenuItemEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+            const restoreConsole = mockConsole();
 
-        // assert
-        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByText("Edit UCSBDiningCommonsMenuItem");
+            expect(screen.queryByTestId("UCSBDiningCommonsMenuItemForm-name")).not.toBeInTheDocument();
+            restoreConsole();
+        });
     });
 
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/UCSBDiningCommonsMenuItem", { params: { id: 17 } }).reply(200, {
+                id: 17,
+                name: "Cheese Pizza",
+                diningCommonsCode: "carillo",
+                station: "Pizza"
+            });
+            axiosMock.onPut('/api/UCSBDiningCommonsMenuItem').reply(200, {
+                id: "17",
+                name: "Beef Stir Fry",
+                diningCommonsCode: "de-la-guerra",
+                station: "International"
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("UCSBDiningCommonsMenuItemForm-name");
+
+            const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+            const nameField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-name");
+            const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+            const stationField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-station");
+            const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItemForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(nameField).toHaveValue("Cheese Pizza");
+            expect(diningCommonsCodeField).toHaveValue("carillo");
+            expect(stationField).toHaveValue("Pizza");
+            expect(submitButton).toBeInTheDocument();
+        });
+
+        test("Changes when you click Update", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBDiningCommonsMenuItemEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("UCSBDiningCommonsMenuItemForm-name");
+
+            const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+            const nameField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-name");
+            const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode");
+            const stationField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-station");
+            const submitButton = screen.getByTestId("UCSBDiningCommonsMenuItemForm-submit");
+
+            expect(idField).toHaveValue("17");
+            expect(nameField).toHaveValue("Cheese Pizza");
+            expect(diningCommonsCodeField).toHaveValue("carillo");
+            expect(stationField).toHaveValue("Pizza");
+
+            expect(submitButton).toBeInTheDocument();
+
+            fireEvent.change(nameField, { target: { value: 'Beef Stir Fry' } })
+            fireEvent.change(diningCommonsCodeField, { target: { value: "de-la-guerra" } })
+            fireEvent.change(stationField, { target: { value: "International" } })
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("UCSBDiningCommonsMenuItem Updated - id: 17 name: Beef Stir Fry diningCommonsCode: de-la-guerra station: International");
+            expect(mockNavigate).toBeCalledWith({ "to": "/diningcommonsmenuitem" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                name: "Beef Stir Fry",
+                diningCommonsCode: "de-la-guerra",
+                station: "International"
+            })); // posted object
+
+        });
+
+       
+    });
 });
 
 


### PR DESCRIPTION
Closes #15 

In this PR, we implement the edit page, and its tests and stories, for UCSBDiningCommonsMenuItem. Here is an image of the page, which can be used at https://team03-irreflexive-dev.dokku-09.cs.ucsb.edu/diningcommonsmenuitem/edit/2
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-1/assets/33270232/f6b184fe-d68b-4a7d-9e82-af58bb6ff102)

Link to storybook: https://ucsb-cs156-f23.github.io/team03-f23-7pm-1/prs/85/storybook/?path=/story/pages-ucsbdiningcommonsmenuitem-ucsbdiningcommonsmenuitemeditpage--default