### PR TITLE
Added UCSBOrganization Table, Table test, and Table stories

### DIFF
--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,26 +1,32 @@
-const ucsbOrganizationFixutres = {
-    oneOrganization: 
-    {
-        "orgCode": "OSLI",
-        "orgTranslationShort": "Student Life",
-        "orgTranslation": "Office of Student Life",
-        "inactive": false
-    },
+const ucsbOrganizationFixtures = {
+    oneOrganization:
+    [
+        {
+            "id": 1,
+            "orgCode": "OSLI",
+            "orgTranslationShort": "Student Life",
+            "orgTranslation": "Office of Student Life",
+            "inactive": false
+        }
+    ],
     threeOrganizations: 
     [
         {
+            "id": 2,
             "orgCode": "SKY	",
             "orgTranslationShort": "Sky Diving",
             "orgTranslation": "Sky Diving Club at UCSB",
             "inactive": false            
         },
         {
+            "id": 3,
             "orgCode": "KRC",
             "orgTranslationShort": "Korean Radio",
             "orgTranslation": "Korean Radio Club",
             "inactive": false
         },
         {
+            "id": 4,
             "orgCode": "ZPR",
             "orgTranslationShort": "Zeta Phi Rho",
             "orgTranslation": "Zeta Phi Rho",
@@ -29,4 +35,4 @@ const ucsbOrganizationFixutres = {
     ]
 };
 
-export { ucsbOrganizationFixutres };
+export { ucsbOrganizationFixtures };

--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -16,21 +16,21 @@ const ucsbOrganizationFixtures = {
             "orgCode": "SKY	",
             "orgTranslationShort": "Sky Diving",
             "orgTranslation": "Sky Diving Club at UCSB",
-            "inactive": false            
+            "inactive": "false"            
         },
         {
             "id": 3,
             "orgCode": "KRC",
             "orgTranslationShort": "Korean Radio",
             "orgTranslation": "Korean Radio Club",
-            "inactive": false
+            "inactive": "false"
         },
         {
             "id": 4,
             "orgCode": "ZPR",
             "orgTranslationShort": "Zeta Phi Rho",
             "orgTranslation": "Zeta Phi Rho",
-            "inactive": false
+            "inactive": "false"
         }
     ]
 };

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
@@ -1,0 +1,130 @@
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom';
+
+function UCSBOrganizationForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+
+    
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents || {}, }
+    );
+
+    const bool_regex = /^(true|false)$/i;
+
+    // Stryker restore all
+   
+    const navigate = useNavigate();
+
+    const testIdPrefix = "UCSBOrganizationForm";
+
+    return (
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="id">Id</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-id"}
+                        id="id"
+                        type="text"
+                        {...register("id")}
+                        value={initialContents.id}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgCode">Organization Code</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgCode"}
+                    id="orgCode"
+                    type="text"
+                    isInvalid={Boolean(errors.orgCode)}
+                    {...register("orgCode", {
+                        required: "Organization Code is required.",
+                        maxLength : {
+                            value: 30,
+                            message: "Max length 30 characters"
+                        }
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgCode?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgTranslationShort">Organization Translation Short</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgTranslationShort"}
+                    id="orgTranslationShort"
+                    type="text"
+                    isInvalid={Boolean(errors.orgTranslationShort)}
+                    {...register("orgTranslationShort", {
+                        required: "Organization Translation Short is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgTranslationShort?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgTranslation">Organization Translation</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgTranslation"}
+                    id="orgTranslation"
+                    type="text"
+                    isInvalid={Boolean(errors.orgTranslation)}
+                    {...register("orgTranslation", {
+                        required: "Organization Translation is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgTranslation?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="inactive">Inactive</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-inactive"}
+                    id="inactive"
+                    type="text"
+                    isInvalid={Boolean(errors.inactive)}
+                    {...register("inactive", {
+                        required: "Inactive must be 'true' or 'false'.",
+                        pattern: bool_regex
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.inactive?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Button
+                type="submit"
+                data-testid={testIdPrefix + "-submit"}
+            >
+                {buttonLabel}
+            </Button>
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid={testIdPrefix + "-cancel"}
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default UCSBOrganizationForm;

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.js
@@ -1,0 +1,65 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBOrganizationUtils"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function UCSBOrganizationTable({
+    ucsbOrganizations,
+    currentUser,
+    testIdPrefix = "UCSBOrganizationTable" }) {
+
+    const navigate = useNavigate();
+
+    const editCallback = (cell) => {
+        navigate(`/ucsborganization/edit/${cell.row.values.id}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/ucsborganization/all"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Organization Code',
+            accessor: 'orgCode',
+        },
+        {
+            Header: 'Organization Translation Short',
+            accessor: 'orgTranslationShort',
+        },
+        {
+            Header: 'Organization Translation',
+            accessor: 'orgTranslation',
+        },
+        {
+            Header: 'Inactive',
+            accessor: 'inactive'
+        }
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix));
+    } 
+
+    return <OurTable
+        data={ucsbOrganizations}
+        columns={columns}
+        testid={testIdPrefix}
+    />;
+};

--- a/frontend/src/main/utils/UCSBOrganizationUtils.js
+++ b/frontend/src/main/utils/UCSBOrganizationUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/ucsborganization",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.js
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm"
+import { ucsbOrganizationFixtures } from 'fixtures/ucsbOrganizationFixtures';
+
+export default {
+    title: 'components/UCSBOrganization/UCSBOrganizationForm',
+    component: UCSBOrganizationForm
+};
+
+const Template = (args) => {
+    return (
+        <UCSBOrganizationForm {...args} />
+    )
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+    buttonLabel: "Create",
+    submitAction: (data) => {
+         console.log("Submit was clicked with data: ", data); 
+         window.alert("Submit was clicked with data: " + JSON.stringify(data));
+    }
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+    initialContents: ucsbOrganizationFixtures.oneOrganization[0],
+    buttonLabel: "Update",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTest.stories.js
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTest.stories.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import UCSBOrganizationTable from 'main/components/UCSBOrganization/UCSBOrganizationTable';
+import { ucsbOrganizationFixtures } from 'fixtures/ucsbOrganizationFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { rest } from "msw";
+
+export default {
+    title: 'components/UCSBOrganization/UCSBOrganizationTable',
+    component: UCSBOrganizationTable
+};
+
+const Template = (args) => {
+    return (
+        <UCSBOrganizationTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    ucsbOrganizations: []
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+    ucsbOrganizations: ucsbOrganizationFixtures.threeOrganizations,
+    currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+    ucsbOrganizations: ucsbOrganizationFixtures.threeOrganizations,
+    currentUser: currentUserFixtures.adminUser,
+}
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.delete('/api/ucsborganization', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+};

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("UCSBOrganizationForm tests", () => {
+    const queryClient = new QueryClient();
+
+    const expectedHeaders = ["Organization Code", "Organization Translation Short", "Organization Translation", "Inactive"];
+    const testId = "UCSBOrganizationForm";
+
+    test("renders correctly with no initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <UCSBOrganizationForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+    });
+
+    test("renders correctly when passing in initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <UCSBOrganizationForm initialContents={ucsbOrganizationFixtures.oneOrganization} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+        expect(screen.getByText(`Id`)).toBeInTheDocument();
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <UCSBOrganizationForm />
+                </Router>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+        const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+    test("that the correct validations are performed", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <UCSBOrganizationForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+        const submitButton = screen.getByText(/Create/);
+        fireEvent.click(submitButton);
+
+        await screen.findByText(/Organization Code is required/);
+        expect(screen.getByText(/Organization Translation Short is required/)).toBeInTheDocument();
+        expect(screen.getByText(/Organization Translation is required/)).toBeInTheDocument();
+        expect(screen.getByText(/Inactive must be 'true' or 'false'/)).toBeInTheDocument();
+
+
+        const orgCodeInput = screen.getByTestId(`${testId}-orgCode`);
+        fireEvent.change(orgCodeInput, { target: { value: "a".repeat(31) } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Max length 30 characters/)).toBeInTheDocument();
+        });
+
+        const inactiveInput = screen.getByTestId(`${testId}-inactive`);
+        fireEvent.change(inactiveInput, { target: { value: "atrue" } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Inactive must be 'true' or 'false'./)).toBeInTheDocument();
+        });
+
+        const suffixes = ["-orgCode", "-orgTranslationShort", "-orgTranslation", "-inactive", "-submit", "-cancel"];
+
+        suffixes.forEach((id) => {
+            expect(screen.getByTestId(`UCSBOrganizationForm${id}`)).toBeInTheDocument();
+        });
+    });
+
+});

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTest.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTest.test.js
@@ -1,0 +1,190 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+describe("UCSBOrganizationTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["id", "Organization Code", "Organization Translation Short", "Organization Translation", "Inactive"];
+  const expectedFields = ["id", "orgCode", "orgTranslationShort", "orgTranslation", "inactive"];
+  const testId = "UCSBOrganizationTable";
+
+  test("renders empty table correctly", () => {
+    
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable ucsbOrganizations={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable ucsbOrganizations={ucsbOrganizationFixtures.threeOrganizations} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("SKY");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-orgCode`)).toHaveTextContent("KRC");
+
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("4");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-orgCode`)).toHaveTextContent("ZPR");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.userOnly;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable ucsbOrganizations={ucsbOrganizationFixtures.threeOrganizations} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("SKY");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`)).toHaveTextContent("Sky Diving");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgTranslation`)).toHaveTextContent("Sky Diving Club at UCSB");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-inactive`)).toHaveTextContent("false");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-orgCode`)).toHaveTextContent("KRC");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-orgTranslationShort`)).toHaveTextContent("Korean Radio");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-orgTranslation`)).toHaveTextContent("Korean Radio Club");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-inactive`)).toHaveTextContent("false");
+
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("4");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-orgCode`)).toHaveTextContent("ZPR");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-orgTranslationShort`)).toHaveTextContent("Zeta Phi Rho");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-orgTranslation`)).toHaveTextContent("Zeta Phi Rho");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-inactive`)).toHaveTextContent("false");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+
+  test("Edit button navigates to the edit page", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable ucsbOrganizations={ucsbOrganizationFixtures.threeOrganizations} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("SKY");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+
+    // act - click the edit button
+    fireEvent.click(editButton);
+
+    // assert - check that the navigate function was called with the expected path
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ucsborganization/edit/2'));
+
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable ucsbOrganizations={ucsbOrganizationFixtures.threeOrganizations} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-orgCode`)).toHaveTextContent("SKY");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+  });
+});


### PR DESCRIPTION
Added a Create table component for UCSBOrganization along with tests and stories to the frontend.

<img width="1512" alt="image" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-1/assets/73411210/3f515a96-bb9c-4a32-98d4-7adb0b8d1816">
<img width="1512" alt="image" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-1/assets/73411210/c66936d3-b843-4973-95c9-458ad77483af">
<img width="1512" alt="image" src="https://github.com/ucsb-cs156-f23/team03-f23-7pm-1/assets/73411210/281b98f7-066f-4285-96da-c7bd616037db">

Closes #20 