### PR TITLE
Fixed Create / Edit Forms' Organization Code Field Bug

### DIFF
--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
@@ -70,10 +70,6 @@ function UCSBOrganizationForm({ initialContents, submitAction, buttonLabel = "Cr
                     isInvalid={Boolean(errors.orgTranslationShort)}
                     {...register("orgTranslationShort", {
                         required: "Organization Translation Short is required.",
-                        maxLength : {
-                            value: 30,
-                            message: "Max length 30 characters"
-                        }
                     })}
                 />
                 <Form.Control.Feedback type="invalid">

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.js
@@ -39,6 +39,28 @@ function UCSBOrganizationForm({ initialContents, submitAction, buttonLabel = "Cr
                 </Form.Group>
             )}
 
+            {!initialContents && (
+                <Form.Group className="mb-3" >
+                <Form.Label htmlFor="orgCode">Organization Code</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-orgCode"}
+                    id="orgCode"
+                    type="text"
+                    isInvalid={Boolean(errors.orgCode)}
+                    {...register("orgCode", {
+                        required: "Organization Code is required.",
+                        maxLength : {
+                            value: 30,
+                            message: "Max length 30 characters"
+                        }
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.orgCode?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+            )}
+
             <Form.Group className="mb-3" >
                 <Form.Label htmlFor="orgTranslationShort">Organization Translation Short</Form.Label>
                 <Form.Control
@@ -107,7 +129,6 @@ function UCSBOrganizationForm({ initialContents, submitAction, buttonLabel = "Cr
             </Button>
 
         </Form>
-
     )
 }
 

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
@@ -16,7 +16,7 @@ jest.mock('react-router-dom', () => ({
 describe("UCSBOrganizationForm tests", () => {
     const queryClient = new QueryClient();
 
-    const expectedHeaders = ["Organization Translation Short", "Organization Translation", "Inactive"];
+    const expectedHeaders = ["Organization Code","Organization Translation Short", "Organization Translation", "Inactive"];
     const testId = "UCSBOrganizationForm";
 
     test("renders correctly with no initialContents", async () => {
@@ -87,12 +87,13 @@ describe("UCSBOrganizationForm tests", () => {
         const submitButton = screen.getByText(/Create/);
         fireEvent.click(submitButton);
 
-        await screen.findByText(/Organization Translation Short is required/);
+        await screen.findByText(/Organization Code is required/);
+        expect(screen.getByText(/Organization Translation Short is required/)).toBeInTheDocument()
         expect(screen.getByText(/Organization Translation is required/)).toBeInTheDocument();
         expect(screen.getByText(/Inactive must be 'true' or 'false'/)).toBeInTheDocument();
 
 
-        const orgCodeInput = screen.getByTestId(`${testId}-orgTranslationShort`);
+        const orgCodeInput = screen.getByTestId(`${testId}-orgCode`);
         fireEvent.change(orgCodeInput, { target: { value: "a".repeat(31) } });
         fireEvent.click(submitButton);
 

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.js
@@ -72,8 +72,11 @@ describe("UCSBOrganizationCreatePage tests", () => {
         )
 
         await waitFor(() => {
-            expect(screen.getByLabelText("Organization Translation Short")).toBeInTheDocument();
+            expect(screen.getByLabelText("Organization Code")).toBeInTheDocument();
         });
+        
+        const orgCodeInput = screen.getByLabelText("Organization Code");
+        expect(orgCodeInput).toBeInTheDocument();
 
         const orgTranslationShortInput = screen.getByLabelText("Organization Translation Short");
         expect(orgTranslationShortInput).toBeInTheDocument();
@@ -87,6 +90,7 @@ describe("UCSBOrganizationCreatePage tests", () => {
         const createButton = screen.getByText("Create");
         expect(createButton).toBeInTheDocument();
 
+        fireEvent.change(orgCodeInput, { target: { value: 'ZPR' } })
         fireEvent.change(orgTranslationShortInput, { target: { value: 'Zeta Phi Rho' } })
         fireEvent.change(orgTranslationInput, { target: { value: 'Zeta Phi Rho' } })
         fireEvent.change(inactiveInput, { target: { value: "false" } })
@@ -95,6 +99,7 @@ describe("UCSBOrganizationCreatePage tests", () => {
         await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
 
         expect(axiosMock.history.post[0].params).toEqual({
+            orgCode: "ZPR",
             orgTranslationShort: "Zeta Phi Rho",
             orgTranslation: "Zeta Phi Rho",
             inactive: "false"


### PR DESCRIPTION
Fixed the appropriate Create Form and Edit Form Organization Code Field Behaviour.

working app deployed on https://team03-mageswarankk-dev.dokku-09.cs.ucsb.edu

Create Page with orgCode Field Available
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-1/assets/73411210/453c11b0-d8ec-4cd6-b110-446b1c32bda5)

Edit Page with Read-Only orgCode Field 
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-1/assets/73411210/836690df-97c5-4851-a04b-b3acb0579c4d)
